### PR TITLE
DataPoint sources are now distinct, and updated the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ You can install the plugin by using the cordova npm repository.
 cordova plugin add org.velardo.cordova-plugin-googlefit
 ```
 
-To use the plugin you need to call the specific functions
-
+To use the plugin you need to call the specific functions.
 ```
-window.plugins.googlefit.getStuff1(
-                  1435708800000,    // Start time in milliseconds
-                  1436368288000,    // Start time in milliseconds
+var startTime = new Date().getTime() - 3 * 24 * 60 * 60 * 1000; // three days ago
+var endTime = new Date().getTime(); // now
+window.plugins.googlefit.getData(
+                  startTime,        // Start time in milliseconds
+                  endTime,          // End time in milliseconds
                   datatypes,        // Datatypes under the URL format specified by GoogleFit
                   function(data) {
                     // Success callback. The data object is a JSON that follows
@@ -46,11 +47,11 @@ window.plugins.googlefit.getStuff1(
                     // The error e is returned in case of problems with the query
                   });
 
-window.plugins.googlefit.getStuff2(
-                  1435708800000,    // Start time in milliseconds
-                  1436368288000,    // Start time in milliseconds
+window.plugins.googlefit.getAggregateData(
+                  startTime,        // Start time in milliseconds
+                  endTime,          // End time in milliseconds
                   datatypes,        // Datatypes under the URL format specified by GoogleFit
-                  datatypes,        // Datatypes under the URL format specified by GoogleFit
+                  dataaggregations, // Aggregate datatypes under the URL format specified by GoogleFit
                   1,                // Duration value of the databucket
                   "DAYS",           // TimeUnit that quantify the duration unit (DAYS, HOURS, MINUTES, SECONDS)
                   0,                // Type of the Buckets (0: ByTime, 1: ByActivityType, 2: ByActivitySegment)
@@ -68,7 +69,7 @@ Valid DataTypes
 
 At the moment the datatypes that are readable from the GoogleFit API are listed below.
 
-Use them by placing the corresponding GoogleFit URL notation in the arrays passed to the GetStuff1 and GetStuff2 JavaScript calls.
+Use them by placing the corresponding GoogleFit URL notation in the arrays passed to the getData and getAggregateData JavaScript calls.
 
 | DataType                                | URL format                               |
 | --------------------------------------- | ---------------------------------------- |

--- a/android/GoogleFit.java
+++ b/android/GoogleFit.java
@@ -20,6 +20,7 @@ import com.google.android.gms.fitness.Fitness;
 import com.google.android.gms.fitness.data.Bucket;
 import com.google.android.gms.fitness.data.DataPoint;
 import com.google.android.gms.fitness.data.DataSet;
+import com.google.android.gms.fitness.data.DataSource;
 import com.google.android.gms.fitness.data.DataType;
 import com.google.android.gms.fitness.data.Field;
 import com.google.android.gms.fitness.request.DataReadRequest;
@@ -452,7 +453,9 @@ public class GoogleFit extends CordovaPlugin {
 
             try {
                 dataPoint_JSON.put("type", dp.getDataType().getName());
-                dataPoint_JSON.put("source", dp.getDataSource());
+                DataSource dataSource = dp.getOriginalDataSource();
+                String appPkgName = dataSource.getAppPackageName();
+                dataPoint_JSON.put("source", appPkgName);
                 dataPoint_JSON.put("start", dateFormat.format(dp.getStartTime(TimeUnit.MILLISECONDS)));
                 dataPoint_JSON.put("end", dateFormat.format(dp.getEndTime(TimeUnit.MILLISECONDS)));
 

--- a/android/GoogleFit.java
+++ b/android/GoogleFit.java
@@ -291,8 +291,8 @@ public class GoogleFit extends CordovaPlugin {
     }
 
     public void getAllStuffs() throws JSONException{
-        // Select the getStuff2: get Buckets+Datasets+Datapoints from GoogleFit according to the query parameters
-        if ("getStuff2".equals(this.savedAction)) {
+        // Select the getAggregateData: get Buckets+Datasets+Datapoints from GoogleFit according to the query parameters
+        if ("getAggregateData".equals(this.savedAction)) {
             long st = this.savedArgs.getJSONObject(0).getLong("startTime");
             long et = this.savedArgs.getJSONObject(0).getLong("endTime");
             List<DataType> dt = JSON2DataType(this.savedArgs.getJSONObject(0).getJSONArray("datatypes"));
@@ -305,8 +305,8 @@ public class GoogleFit extends CordovaPlugin {
         }
     
     
-        // Select the getStuff1: get Datasets+Datapoints from GoogleFit according to the query parameters
-        if ("getStuff1".equals(this.savedAction)) {
+        // Select the getData: get Datasets+Datapoints from GoogleFit according to the query parameters
+        if ("getData".equals(this.savedAction)) {
             long st = this.savedArgs.getJSONObject(0).getLong("startTime");
             long et = this.savedArgs.getJSONObject(0).getLong("endTime");
             JSONArray _dt = this.savedArgs.getJSONObject(0).getJSONArray("datatypes");

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.5.0",
+    "version": "1.0.0",
     "name": "org.velardo.cordova-plugin-googlefit",
     "cordova_name": "GoogleFit",
     "description": "Use your GoogleFit to gather activity information.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="org.velardo.cordova-plugin-googlefit"
-        version="0.3.0">
+        version="1.0.0">
 
   <name>GoogleFit</name>
 

--- a/src/android/GoogleFit.java
+++ b/src/android/GoogleFit.java
@@ -20,6 +20,7 @@ import com.google.android.gms.fitness.Fitness;
 import com.google.android.gms.fitness.data.Bucket;
 import com.google.android.gms.fitness.data.DataPoint;
 import com.google.android.gms.fitness.data.DataSet;
+import com.google.android.gms.fitness.data.DataSource;
 import com.google.android.gms.fitness.data.DataType;
 import com.google.android.gms.fitness.data.Field;
 import com.google.android.gms.fitness.request.DataReadRequest;
@@ -424,7 +425,9 @@ public class GoogleFit extends CordovaPlugin {
 
             try {
                 dataPoint_JSON.put("type", dp.getDataType().getName());
-                dataPoint_JSON.put("source", dp.getDataSource());
+                DataSource dataSource = dp.getOriginalDataSource();
+                String appPkgName = dataSource.getAppPackageName();
+                dataPoint_JSON.put("source", appPkgName);
                 dataPoint_JSON.put("start", dateFormat.format(dp.getStartTime(TimeUnit.MILLISECONDS)));
                 dataPoint_JSON.put("end", dateFormat.format(dp.getEndTime(TimeUnit.MILLISECONDS)));
 

--- a/src/android/GoogleFit.java
+++ b/src/android/GoogleFit.java
@@ -281,8 +281,8 @@ public class GoogleFit extends CordovaPlugin {
     @Override
     public boolean execute(String action, final JSONArray args, final CallbackContext callbackContext) throws JSONException {
 
-        // Select the getStuff2: get Buckets+Datasets+Datapoints from GoogleFit according to the query parameters
-        if ("getStuff2".equals(action)) {
+        // Select the getAggregateData: get Buckets+Datasets+Datapoints from GoogleFit according to the query parameters
+        if ("getAggregateData".equals(action)) {
             long st = args.getJSONObject(0).getLong("startTime");
             long et = args.getJSONObject(0).getLong("endTime");
             List<DataType> dt = JSON2DataType(args.getJSONObject(0).getJSONArray("datatypes"));
@@ -294,8 +294,8 @@ public class GoogleFit extends CordovaPlugin {
             cordova.getThreadPool().execute(new GetStuff(queryDataWithBuckets(st, et, dt, dta, du, tu, tb), callbackContext));
         }
 
-        // Select the getStuff1: get Datasets+Datapoints from GoogleFit according to the query parameters
-        if ("getStuff1".equals(action)) {
+        // Select the getData: get Datasets+Datapoints from GoogleFit according to the query parameters
+        if ("getData".equals(action)) {
 
             long st = args.getJSONObject(0).getLong("startTime");
             long et = args.getJSONObject(0).getLong("endTime");

--- a/www/GoogleFit.js
+++ b/www/GoogleFit.js
@@ -1,11 +1,11 @@
 function GoogleFit() {
 }
 
-GoogleFit.prototype.getStuff1 = function (startTime, endTime, datatypes, successCallback, failureCallback) {
+GoogleFit.prototype.getData = function (startTime, endTime, datatypes, successCallback, failureCallback) {
   cordova.exec(successCallback,
                failureCallback,
                "GoogleFit",
-               "getStuff1",
+               "getData",
                [{
                  "startTime" : startTime,
                  "endTime" : endTime,
@@ -14,11 +14,11 @@ GoogleFit.prototype.getStuff1 = function (startTime, endTime, datatypes, success
 };
 
 
-GoogleFit.prototype.getStuff2 = function (startTime, endTime, datatypes, dataaggregations, durationBucket, timeUnitBucket, typeBucket, successCallback, failureCallback) {
+GoogleFit.prototype.getAggregateData = function (startTime, endTime, datatypes, dataaggregations, durationBucket, timeUnitBucket, typeBucket, successCallback, failureCallback) {
   cordova.exec(successCallback,
                failureCallback,
                "GoogleFit",
-               "getStuff2",
+               "getAggregateData",
                [{
                  "startTime" : startTime,
                  "endTime" : endTime,


### PR DESCRIPTION
The source of data points is now much more useful; what was before `"DataSource{derived:Application{com.google.android.gms::null}:overlay_explicit_input_local:DataType{com.google.step_count.delta[steps(i)]}}"`
is now `"com.google.android.apps.fitness"`.

The version is now 1.0.0 because renaming `getStuff1` and `getStuff2` to `getData` and `getAggregateData`, respectively, is an incompatible API change.
